### PR TITLE
Original example did not compile in Arduino IDE v1.6.4 in linux givin…

### DIFF
--- a/Adafruit_TMP007.h
+++ b/Adafruit_TMP007.h
@@ -19,7 +19,10 @@
 #else
  #include "WProgram.h"
 #endif
-#include <Adafruit_Sensor.h>
+// During compilaton of example code this generated a cannot find  error
+// in Arduino IDE v 1.6.4 on Linux, adding the include for the sensor library
+// to the sketch using the Adafruit_TMP007_Library works in Arduino v1.6.4 IDE 
+//#include <Adafruit_Sensor.h>
 #include "Wire.h"
 
 // uncomment for debugging!

--- a/examples/tmp007/tmp007.ino
+++ b/examples/tmp007/tmp007.ino
@@ -13,7 +13,8 @@
   Written by Limor Fried/Ladyada for Adafruit Industries.  
   BSD license, all text above must be included in any redistribution
  ****************************************************/
-
+// Adafruit Unified Sensor Library required
+#include <Adafruit_Sensor.h>
 #include <Wire.h>
 #include "Adafruit_TMP007.h"
 


### PR DESCRIPTION
…g a not

found error for the Adafruit Unified Sensor library despite the library being
installed in the IDE. Commenting out the include for the Adafruit Unified Sensor
library in the TMP007 library and adding the include for the sensor library
to the example sketch compiled and worked in Arduino IDE v 1.6.4 in linux
