### PR TITLE
Fix build error on Arduino Zero.

### DIFF
--- a/Adafruit_TMP007.cpp
+++ b/Adafruit_TMP007.cpp
@@ -15,7 +15,6 @@
  ****************************************************/
 
 #include "Adafruit_TMP007.h"
-#include <util/delay.h>
 
 //#define TESTDIE 0x0C78
 //#define TESTVOLT 0xFEED


### PR DESCRIPTION
Arduino Zero doesn't have the util/delay.h header. Since this isn't actually
needed, just remove it.
